### PR TITLE
Bump version to release new options

### DIFF
--- a/devcontainer-feature.json
+++ b/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "llvm",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "name": "llvm",
   "documentationURL": "https://github.com/devcontainers-community/features-llvm",
   "description": "Installs llvm on debian based systems",


### PR DESCRIPTION
The last release was in August 2023, but there have been changes since. A new release should be created